### PR TITLE
#70 add gold button styles and logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# vscode 
+.vscode/

--- a/src/components/Lesson.tsx
+++ b/src/components/Lesson.tsx
@@ -206,7 +206,6 @@ const Lesson = ({ lesson }: { lesson: LessonType }): React.ReactElement => {
   const slide = lesson.slides[currentSlide]
   const isFirstSlide = currentSlide === 0
   const isLastSlide = currentSlide + 1 === numberOfSlides
-  const is2ndToLastSlide = currentSlide + 1 === numberOfSlides - 1
 
   const { library, account } = useActiveWeb3React()
   const walletAddress = account
@@ -359,7 +358,7 @@ const Lesson = ({ lesson }: { lesson: LessonType }): React.ReactElement => {
   const poapCode = localStorage.getItem(`poap-${lesson.slug}`) || poapData.code
 
   const hostname = window?.location.hostname
-  
+
   return (
     <Slide
       p={8}
@@ -622,7 +621,7 @@ const Lesson = ({ lesson }: { lesson: LessonType }): React.ReactElement => {
         <HStack>
           <Button
             ref={buttonRightRef}
-            variant={is2ndToLastSlide ? 'primaryBig2ndLast' : isLastSlide ? 'primaryBigLast' : 'primaryBig'}
+            variant={isLastSlide ? 'primaryBigLast' : 'primaryBig'}
             size="lg"
             disabled={
               (isLastSlide && !isPoapClaimed) ||

--- a/src/components/Lesson.tsx
+++ b/src/components/Lesson.tsx
@@ -206,6 +206,7 @@ const Lesson = ({ lesson }: { lesson: LessonType }): React.ReactElement => {
   const slide = lesson.slides[currentSlide]
   const isFirstSlide = currentSlide === 0
   const isLastSlide = currentSlide + 1 === numberOfSlides
+  const is2ndToLastSlide = currentSlide + 1 === numberOfSlides - 1
 
   const { library, account } = useActiveWeb3React()
   const walletAddress = account
@@ -358,7 +359,7 @@ const Lesson = ({ lesson }: { lesson: LessonType }): React.ReactElement => {
   const poapCode = localStorage.getItem(`poap-${lesson.slug}`) || poapData.code
 
   const hostname = window?.location.hostname
-
+  
   return (
     <Slide
       p={8}
@@ -621,7 +622,7 @@ const Lesson = ({ lesson }: { lesson: LessonType }): React.ReactElement => {
         <HStack>
           <Button
             ref={buttonRightRef}
-            variant="primaryBig"
+            variant={is2ndToLastSlide ? 'primaryBig2ndLast' : isLastSlide ? 'primaryBigLast' : 'primaryBig'}
             size="lg"
             disabled={
               (isLastSlide && !isPoapClaimed) ||

--- a/src/theme/components/button.tsx
+++ b/src/theme/components/button.tsx
@@ -62,21 +62,9 @@ export default {
               ...primaryStyle,
             },
       },
-      primaryBig2ndLast: {
-        background:
-        'linear-gradient(270deg, #FFFCF9 -44.74%, #F77B54 -11.81%, #ffffff22 94.44%)',
-        backdropFilter: 'blur(50px)',
-        borderRadius: '60px',
-        _hover: isMobile
-          ? {}
-          : {
-              ...paddingBig,
-              ...primaryStyle,
-            },
-      },
       primaryBigLast: {
         background:
-        'linear-gradient(270deg, #FFFCF9 -44.74%, #F77B54 -11.81%, #916AB8 94.44%)',
+          'linear-gradient(270deg, #FFFCF9 -44.74%, #F77B54 -11.81%, #916AB8 94.44%)',
         backdropFilter: 'blur(50px)',
         borderRadius: '60px',
         _hover: isMobile

--- a/src/theme/components/button.tsx
+++ b/src/theme/components/button.tsx
@@ -62,6 +62,30 @@ export default {
               ...primaryStyle,
             },
       },
+      primaryBig2ndLast: {
+        background:
+        'linear-gradient(270deg, #FFFCF9 -44.74%, #F77B54 -11.81%, #ffffff22 94.44%)',
+        backdropFilter: 'blur(50px)',
+        borderRadius: '60px',
+        _hover: isMobile
+          ? {}
+          : {
+              ...paddingBig,
+              ...primaryStyle,
+            },
+      },
+      primaryBigLast: {
+        background:
+        'linear-gradient(270deg, #FFFCF9 -44.74%, #F77B54 -11.81%, #916AB8 94.44%)',
+        backdropFilter: 'blur(50px)',
+        borderRadius: '60px',
+        _hover: isMobile
+          ? {}
+          : {
+              ...paddingBig,
+              ...primaryStyle,
+            },
+      },
       secondary: {
         background: '#3F3253',
         backdropFilter: 'blur(50px)',


### PR DESCRIPTION
Adds gold styles to buttons. There were two gold styles:
- one for 2nd to last slides (gold)
- one for the last slides (purple/gold)

Now the buttons match the status bar at every step. 

All the disabling logic is unchanged.

Also adds .gitignore entry for the .vscode folder

![gold](https://user-images.githubusercontent.com/101533082/158091728-40042b5a-6b5c-4f42-85bb-5c11655278f7.png)

![purple-gold](https://user-images.githubusercontent.com/101533082/158091727-1b8ecce9-76bf-4c8e-9787-49408a3ff891.png)


